### PR TITLE
use compatible version of std for server

### DIFF
--- a/examples/final_server.ts
+++ b/examples/final_server.ts
@@ -1,4 +1,4 @@
-import { serve } from "https://deno.land/std/http/server.ts";
+import { serve } from "https://deno.land/std@0.106.0/http/server.ts";
 import router from "./router.ts";
 import { Logger } from "https://raw.githubusercontent.com/deepakshrma/deno_util/master/logger.ts";
 


### PR DESCRIPTION
The return type of serve used to be Server (which is async iterable) up until std version 0.106.0. Starting in version 0.107.0 of std, the signature of serve changed to accept a Handler instead (and return Promise<void>). Reference: https://stackoverflow.com/questions/70963882/deno-serve-imported-from-std-http-server-ts-is-not-async-iterable